### PR TITLE
Add genome2UCSC mapping for GRCm39

### DIFF
--- a/R/tximeta.R
+++ b/R/tximeta.R
@@ -535,6 +535,8 @@ genome2UCSC <- function(x) {
     "hg38"
   } else if (x == "GRCm38") {
     "mm10"
+  } else if (x == "GRCm39") {
+    "mm39"
   } else {
     x
   }


### PR DESCRIPTION
Hi @mikelove - very sorry, I did not consider that the `genome2UCSC` function needed an update as well in #77... 